### PR TITLE
Bug Fix :voices and model dropdown non rendering

### DIFF
--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -796,7 +796,7 @@
 										<option value="" disabled selected={!TTS_VOICE}>{$i18n.t('Select a voice...')}
 										</option>
 
-										{#each voices as voice (voice.id)}
+										{#each voices as voice}
 											<option value={voice.id}>{voice.name}</option>
 										{/each}
 									</select>


### PR DESCRIPTION
Fixed the bug that would not let the voices and model drop down to not render when swtich from webapi to customtts (error was Keys at index 0 and 1 with value 'undefined' are duplicates) closing and merging this branch to main.